### PR TITLE
Added customizable title

### DIFF
--- a/TA-thehive/bin/thehive_alert_create_alert.py
+++ b/TA-thehive/bin/thehive_alert_create_alert.py
@@ -200,6 +200,13 @@ def create_alert(config, results):
             newDescription = str(row.pop(id)) # grabs that field's value 
             if newDescription not in [None, '']:
                 description = newDescription
+
+        # check if title contains a field name instead of a string. if yes, strip it from the row and assign value to title
+        if config['title'] in row:
+            id = config['title']
+            newTitle = str(row.pop(id)) # grabs that field's value 
+            if newTitle not in [None, '']:
+                title = newTitle
  
         # check if the field th_msg exists and strip it from the row. The value will be used as message attached to artifacts
         if 'th_msg' in row:

--- a/TA-thehive/bin/thehive_alert_create_alert.py
+++ b/TA-thehive/bin/thehive_alert_create_alert.py
@@ -183,6 +183,7 @@ def create_alert(config, results):
     alertRef = 'SPK' + str(int(time.time()))
 
     description = config['description']
+    title = config['title']
     for row in results:
         # Splunk makes a bunch of dumb empty multivalue fields - we filter those out here 
         row = {key: value for key, value in row.iteritems() if not key.startswith("__mv_")}
@@ -272,7 +273,7 @@ def create_alert(config, results):
             logging.debug("SourceRef is %s and attributes are %s" % (srcRef,  artifact_list))
 
             payload = json.dumps(dict(
-                title = config['title'],
+                title = title,
                 description = description,
                 tags = config['tags'],
                 severity = config['severity'],


### PR DESCRIPTION
Added the same behaviour as for 'description', the alert title can be customized via a field from the Splunk results.